### PR TITLE
Update gtest.rb

### DIFF
--- a/gtest.rb
+++ b/gtest.rb
@@ -6,7 +6,7 @@ class Gtest <Formula
   md5 '7e27f5f3b79dd1ce9092e159cdbd0635'
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
+    system "./configure", "CPPFLAGS=-DGTEST_HAS_TR1_TUPLE=0", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
     system "make install"
   end
 end


### PR DESCRIPTION
I've added a compilation flag "CPPFLAGS=-DGTEST_HAS_TR1_TUPLE=0" to be able to build gtest on OSX 10.9 / Xcode 5.0.1.  I am not sure how to obtain MacOS version, then I would have added 'if' condition. Please test it on previous versions of OSX.
