### PR TITLE
Change to unstable version 2.5.4

### DIFF
--- a/mongodb-dev.rb
+++ b/mongodb-dev.rb
@@ -2,19 +2,25 @@ require 'formula'
 
 class MongodbDev < Formula
   homepage 'http://www.mongodb.org/'
-  url 'https://github.com/mongodb/mongo/archive/r2.4.4.tar.gz'
-  sha1 '8aa03a2a4acd9ba4f0cbc0a9bdb6742409ada14c'
-  version '2.4.4'
+  url 'https://github.com/mongodb/mongo/archive/r2.5.4.tar.gz'
+  sha1 '0d8b8dad3b5909af2b9b7ba7ed22d5cb0a7cfd98'
+  version '2.5.4'
 
   depends_on 'scons'
   depends_on 'boost'
 
-  def patches
-    DATA
-  end
+  conflicts_with "mongodb", :because=>"installs the same binaries"
 
   def install
-    system "scons", "--use-system-boost", "--prefix=#{prefix}", "install"
+    args =  ["--full", "--use-system-boost", "--prefix=#{prefix}"]
+
+    if ENV.compiler == :clang && MacOS.version >= :mavericks
+        args << "--64"
+        args << "--libc++"
+        args << "--osx-version-min=10.9"
+    end
+
+    system "scons", "install", *args
   end
 
   test do
@@ -22,18 +28,3 @@ class MongodbDev < Formula
   end
 
 end
-
-__END__
-diff --git a/SConstruct b/SConstruct
-index a25c99d..6f7662a 100644
---- a/SConstruct
-+++ b/SConstruct
-@@ -783,6 +783,8 @@ if not use_system_version_of_library("pcre"):
- if not use_system_version_of_library("boost"):
-     env.Prepend(CPPPATH=['$BUILD_DIR/third_party/boost'],
-                 CPPDEFINES=['BOOST_ALL_NO_LIB'])
-+else:
-+    env.Prepend(CPPPATH=['/usr/local/include'])
-
- env.Prepend(CPPPATH=['$BUILD_DIR/third_party/s2'])
- env.Prepend(CPPPATH=['$BUILD_DIR/third_party/libstemmer_c/include'])


### PR DESCRIPTION
The current stable release 2.4.8 does not support libc++ (i.e. OS X Mavericks)

See this issue: https://github.com/ros/homebrew-hydro/issues/12
- Add special handling to fix building on OS X 10.9 Mavericks.
- The packages ros_warehose and moveit_ros_warehose for which this formula was created build (tested on OS X 10.9).
- Removed patch which seems to be obsolete.

It should be tested on none 10.9 OS X, which I have not done.
