### PR TITLE
Two fixes for the gtest formula

### DIFF
--- a/gtest.rb
+++ b/gtest.rb
@@ -13,6 +13,7 @@ class Gtest <Formula
 
   def install
     system "./configure", "CPPFLAGS=-DGTEST_HAS_TR1_TUPLE=0", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
+    inreplace 'scripts/gtest-config', '`dirname $0`', '$bindir'
     system "make install"
   end
 end


### PR DESCRIPTION
This fixes two issues with the gtest formula.

First, it pulls in the fix from this issue on homebrew:
https://github.com/Homebrew/homebrew/issues/7009

Second, it removes an extra + in the diff that caused `gtest_port.h` to have a 

```
+namespace std {
```

in it after patching. 
